### PR TITLE
Timer object fix (fixes preview snapshot display), reduce SDL2 input lag

### DIFF
--- a/src/sdl2/sdl2_input.cpp
+++ b/src/sdl2/sdl2_input.cpp
@@ -98,6 +98,8 @@ Input::Player *SDL2Input::Update(int rotate) {
         }
     }
 
+    SDL_JoystickUpdate(); // ensure all joysticks are up-to-date to remove lag
+
     for (int i = 0; i < PLAYER_COUNT; i++) {
 
         if (!players[i].enabled) {

--- a/src/skeleton/timer.cpp
+++ b/src/skeleton/timer.cpp
@@ -7,8 +7,6 @@
 
 #include "timer.h"
 
-static struct timeval start;
-
 Timer::Timer() {
     Reset();
 }

--- a/src/skeleton/timer.h
+++ b/src/skeleton/timer.h
@@ -19,6 +19,9 @@ public:
     virtual unsigned long GetMillis();
 
     virtual unsigned int GetSeconds();
+
+private:
+    struct timeval start;
 };
 
 #endif //_TIMER_H_


### PR DESCRIPTION
By calling SDL_JoystickUpdate() explicitly every frame, the input lag is hopefully reduced. This works well in UAE4All2 in SDL1.2. It should work in SDL2, too. There was a report of input lag on Vita TV. This could potentially fix it.