### PR TITLE
PSP2: Add sharp-bilinear-simple shader back in.

### DIFF
--- a/source/platforms/psp2/psp2_shaders.cpp
+++ b/source/platforms/psp2/psp2_shaders.cpp
@@ -15,8 +15,8 @@
 //#include "scale2x_v.h"
 #include "sharp_bilinear_f.h"
 #include "sharp_bilinear_v.h"
-//#include "sharp_bilinear_simple_f.h"
-//#include "sharp_bilinear_simple_v.h"
+#include "sharp_bilinear_simple_f.h"
+#include "sharp_bilinear_simple_v.h"
 //#include "xbr_2x_noblend_f.h"
 //#include "xbr_2x_noblend_v.h"
 //#include "fxaa_v.h"
@@ -42,6 +42,8 @@ PSP2ShaderList::PSP2ShaderList(const std::string &shadersPath) : ShaderList(shad
         create((SceGxmProgram *) lcd3x_v, (SceGxmProgram *) lcd3x_f));
     add("sharp+scan",
         create((SceGxmProgram *) sharp_bilinear_v, (SceGxmProgram *) sharp_bilinear_f));
+    add("sharp",
+        create((SceGxmProgram *) sharp_bilinear_simple_v, (SceGxmProgram *) sharp_bilinear_simple_f));
 
     printf("PSP2ShaderList: found %i shaders\n", getCount() - 1);
 }


### PR DESCRIPTION
This is a good shader for users like me who hate scanline, but
want a sharp picture without pixelwobble. The shader looks great
with some games like Air Gallet with zero slow-down. It gives a
sharper picture than just 'bilinear+none', and the pixels remain
square.

I suppose it shouldn't hurt to have it as an option, so I am
adding it back in. I hope this is acceptable.